### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/tests/Registry/SettingDefinitionRegistryTest.php
+++ b/tests/Registry/SettingDefinitionRegistryTest.php
@@ -33,14 +33,14 @@ class SettingDefinitionRegistryTest extends TestCase
             new DecimalSetting()
         ]);
 
-        $this->assertSame(2, count($registry));
+        $this->assertCount(2, $registry);
     }
 
     public function testAdd()
     {
         $registry = new SettingDefinitionRegistry();
         $registry->add(new StringSetting())->add(new IntegerSetting());
-        $this->assertSame(2, count($registry));
+        $this->assertCount(2, $registry);
     }
 
     public function testHas()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Using the `assertCount` to assert expected is same as result count.